### PR TITLE
Add System Health Dashboard

### DIFF
--- a/FEATURES_SCRATCHPAD.md
+++ b/FEATURES_SCRATCHPAD.md
@@ -10,11 +10,11 @@ This document tracks potential features to implement in the PortGuardian applica
   - [ ] Heat maps showing process resource consumption
   - [ ] Implementation notes: Consider using Chart.js or D3.js for frontend visualizations
 
-- [ ] **System Health Dashboard**
-  - [ ] Overall system metrics (CPU, RAM, disk usage, network throughput)
+- [x] **System Health Dashboard**
+  - [x] Overall system metrics (CPU, RAM, disk usage, network throughput)
   - [ ] Temperature monitoring for critical components
-  - [ ] System uptime and load averages
-  - [ ] Implementation notes: Use psutil for backend data collection
+  - [x] System uptime and load averages
+  - [x] Implementation notes: Used psutil for backend data collection in utils/system_monitor.py
 
 - [ ] **Notification System**
   - [ ] Email/SMS alerts when critical processes crash

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from utils.port_scanner import get_open_ports
 from utils.process_manager import get_process_info, kill_process
+from utils.system_monitor import get_all_system_metrics
 
 # Configure logging
 logging.basicConfig(
@@ -127,6 +128,29 @@ def api_process(pid):
     if not process_info:
         return jsonify({'error': 'Process not found'}), 404
     return jsonify(process_info)
+
+@app.route('/system-health')
+@login_required
+def system_health():
+    """System health dashboard showing CPU, memory, disk, and network metrics."""
+    try:
+        metrics = get_all_system_metrics()
+        return render_template('system_health.html', metrics=metrics)
+    except Exception as e:
+        logger.error(f"Error in system health dashboard: {str(e)}")
+        flash(f"Error retrieving system metrics: {str(e)}", 'danger')
+        return redirect(url_for('index'))
+
+@app.route('/api/system-health')
+@login_required
+def api_system_health():
+    """API endpoint to get system health metrics as JSON."""
+    try:
+        metrics = get_all_system_metrics()
+        return jsonify(metrics)
+    except Exception as e:
+        logger.error(f"Error in system health API: {str(e)}")
+        return jsonify({'error': str(e)}), 500
 
 @app.route('/export')
 @login_required

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('system_health') }}">
+                            <i class="fas fa-heartbeat me-1"></i> System Health
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('export_data') }}" target="_blank">
                             <i class="fas fa-file-export me-1"></i> Export Data
                         </a>

--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -1,0 +1,383 @@
+{% extends 'base.html' %}
+
+{% block title %}System Health - PortGuardian{% endblock %}
+
+{% block extra_css %}
+<style>
+    .metric-card {
+        transition: all 0.3s ease;
+        margin-bottom: 20px;
+    }
+    .metric-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 10px 20px rgba(0,0,0,0.1);
+    }
+    .progress {
+        height: 25px;
+        margin-bottom: 15px;
+    }
+    .progress-bar {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+    }
+    .system-info-item {
+        padding: 10px;
+        border-bottom: 1px solid #eee;
+    }
+    .system-info-item:last-child {
+        border-bottom: none;
+    }
+    .refresh-btn {
+        position: fixed;
+        bottom: 30px;
+        right: 30px;
+        z-index: 1000;
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+    }
+    .disk-usage-bar {
+        height: 30px;
+        border-radius: 4px;
+        margin-bottom: 10px;
+    }
+    .network-card {
+        border-left: 4px solid #007bff;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col-12">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Dashboard</a></li>
+                <li class="breadcrumb-item active">System Health</li>
+            </ol>
+        </nav>
+    </div>
+</div>
+
+<div class="row mb-4">
+    <div class="col-md-12">
+        <div class="card shadow">
+            <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                <h4 class="mb-0"><i class="fas fa-server me-2"></i>System Health Dashboard</h4>
+                <div>
+                    <span id="lastUpdated" class="badge bg-light text-dark me-2">
+                        Last updated: {{ metrics.timestamp }}
+                    </span>
+                    <button id="refreshBtn" class="btn btn-light btn-sm">
+                        <i class="fas fa-sync-alt me-1"></i>Refresh
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- System Overview -->
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card shadow metric-card">
+            <div class="card-header bg-info text-white">
+                <h5 class="mb-0"><i class="fas fa-info-circle me-2"></i>System Information</h5>
+            </div>
+            <div class="card-body">
+                <div class="system-info-item">
+                    <strong>Operating System:</strong> {{ metrics.system_info.system }} {{ metrics.system_info.release }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Hostname:</strong> {{ metrics.system_info.node }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Machine Type:</strong> {{ metrics.system_info.machine }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Processor:</strong> {{ metrics.system_info.processor }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Python Version:</strong> {{ metrics.system_info.python_version }}
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-6">
+        <div class="card shadow metric-card">
+            <div class="card-header bg-success text-white">
+                <h5 class="mb-0"><i class="fas fa-clock me-2"></i>Uptime & Load</h5>
+            </div>
+            <div class="card-body">
+                <div class="system-info-item">
+                    <strong>System Uptime:</strong> {{ metrics.uptime_info.uptime_formatted }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Boot Time:</strong> {{ metrics.uptime_info.boot_time }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Load Average (1, 5, 15 min):</strong> 
+                    {{ "%.2f"|format(metrics.load_info.load_1_min) }}, 
+                    {{ "%.2f"|format(metrics.load_info.load_5_min) }}, 
+                    {{ "%.2f"|format(metrics.load_info.load_15_min) }}
+                </div>
+                <div class="system-info-item">
+                    <strong>Normalized Load (1, 5, 15 min):</strong> 
+                    {{ "%.2f"|format(metrics.load_info.normalized_load_1) }}, 
+                    {{ "%.2f"|format(metrics.load_info.normalized_load_5) }}, 
+                    {{ "%.2f"|format(metrics.load_info.normalized_load_15) }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- CPU & Memory -->
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card shadow metric-card">
+            <div class="card-header bg-danger text-white">
+                <h5 class="mb-0"><i class="fas fa-microchip me-2"></i>CPU Usage</h5>
+            </div>
+            <div class="card-body">
+                <h6>Overall CPU Usage</h6>
+                <div class="progress mb-4">
+                    <div class="progress-bar bg-danger" role="progressbar" 
+                         style="width: {{ metrics.cpu_info.overall_percent }}%">
+                        {{ "%.1f"|format(metrics.cpu_info.overall_percent) }}%
+                    </div>
+                </div>
+                
+                <h6>CPU Details</h6>
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div class="system-info-item">
+                            <strong>Physical Cores:</strong> {{ metrics.cpu_info.physical_cores }}
+                        </div>
+                        <div class="system-info-item">
+                            <strong>Logical Cores:</strong> {{ metrics.cpu_info.total_cores }}
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="system-info-item">
+                            <strong>Current Frequency:</strong> 
+                            {% if metrics.cpu_info.cpu_freq.current %}
+                                {{ "%.2f"|format(metrics.cpu_info.cpu_freq.current) }} MHz
+                            {% else %}
+                                N/A
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                
+                <h6>Per-Core Usage</h6>
+                <div class="row">
+                    {% for cpu_percent in metrics.cpu_info.cpu_percent %}
+                    <div class="col-md-6 mb-2">
+                        <div class="d-flex justify-content-between mb-1">
+                            <span>Core {{ loop.index0 }}</span>
+                            <span>{{ "%.1f"|format(cpu_percent) }}%</span>
+                        </div>
+                        <div class="progress" style="height: 15px;">
+                            <div class="progress-bar bg-danger" role="progressbar" 
+                                 style="width: {{ cpu_percent }}%"></div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-6">
+        <div class="card shadow metric-card">
+            <div class="card-header bg-warning text-white">
+                <h5 class="mb-0"><i class="fas fa-memory me-2"></i>Memory Usage</h5>
+            </div>
+            <div class="card-body">
+                <h6>RAM Usage</h6>
+                <div class="progress mb-2">
+                    <div class="progress-bar bg-warning text-dark" role="progressbar" 
+                         style="width: {{ metrics.memory_info.virtual.percent }}%">
+                        {{ metrics.memory_info.virtual.percent }}%
+                    </div>
+                </div>
+                <div class="row mb-4">
+                    <div class="col-md-4 text-center">
+                        <div class="small text-muted">Total</div>
+                        <div class="fw-bold">{{ metrics.memory_info.virtual.total_gb }} GB</div>
+                    </div>
+                    <div class="col-md-4 text-center">
+                        <div class="small text-muted">Used</div>
+                        <div class="fw-bold">{{ metrics.memory_info.virtual.used_gb }} GB</div>
+                    </div>
+                    <div class="col-md-4 text-center">
+                        <div class="small text-muted">Available</div>
+                        <div class="fw-bold">{{ metrics.memory_info.virtual.available_gb }} GB</div>
+                    </div>
+                </div>
+                
+                <h6>Swap Usage</h6>
+                <div class="progress mb-2">
+                    <div class="progress-bar bg-info" role="progressbar" 
+                         style="width: {{ metrics.memory_info.swap.percent }}%">
+                        {{ metrics.memory_info.swap.percent }}%
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-4 text-center">
+                        <div class="small text-muted">Total</div>
+                        <div class="fw-bold">{{ metrics.memory_info.swap.total_gb }} GB</div>
+                    </div>
+                    <div class="col-md-4 text-center">
+                        <div class="small text-muted">Used</div>
+                        <div class="fw-bold">{{ metrics.memory_info.swap.used_gb }} GB</div>
+                    </div>
+                    <div class="col-md-4 text-center">
+                        <div class="small text-muted">Free</div>
+                        <div class="fw-bold">{{ metrics.memory_info.swap.free_gb }} GB</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Disk Usage -->
+<div class="row mb-4">
+    <div class="col-md-12">
+        <div class="card shadow metric-card">
+            <div class="card-header bg-secondary text-white">
+                <h5 class="mb-0"><i class="fas fa-hdd me-2"></i>Disk Usage</h5>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    {% for partition in metrics.disk_info.partitions %}
+                    <div class="col-md-6 mb-4">
+                        <div class="card">
+                            <div class="card-header bg-light">
+                                <div class="d-flex justify-content-between">
+                                    <span><strong>{{ partition.mountpoint }}</strong></span>
+                                    <span class="badge bg-secondary">{{ partition.fstype }}</span>
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <div class="d-flex justify-content-between mb-1">
+                                    <span>Usage: {{ partition.percent }}%</span>
+                                    <span>{{ partition.used_gb }} GB / {{ partition.total_gb }} GB</span>
+                                </div>
+                                <div class="progress disk-usage-bar">
+                                    <div class="progress-bar bg-{{ 'danger' if partition.percent > 90 else 'warning' if partition.percent > 70 else 'success' }}" 
+                                         role="progressbar" style="width: {{ partition.percent }}%">
+                                        {{ partition.percent }}%
+                                    </div>
+                                </div>
+                                <div class="small text-muted">
+                                    <strong>Device:</strong> {{ partition.device }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Network Interfaces -->
+<div class="row mb-4">
+    <div class="col-md-12">
+        <div class="card shadow metric-card">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0"><i class="fas fa-network-wired me-2"></i>Network Interfaces</h5>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    {% for interface_name, interface in metrics.network_info.interfaces.items() %}
+                    <div class="col-md-6 mb-3">
+                        <div class="card network-card">
+                            <div class="card-header bg-light">
+                                <div class="d-flex justify-content-between">
+                                    <span><strong>{{ interface_name }}</strong></span>
+                                    {% if interface.stats and interface.stats.isup %}
+                                    <span class="badge bg-success">UP</span>
+                                    {% else %}
+                                    <span class="badge bg-danger">DOWN</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                {% if interface.addresses %}
+                                <h6>Addresses</h6>
+                                <ul class="list-group mb-3">
+                                    {% for addr in interface.addresses %}
+                                    <li class="list-group-item">
+                                        <div><strong>{{ addr.address }}</strong></div>
+                                        {% if addr.netmask %}
+                                        <div class="small text-muted">Netmask: {{ addr.netmask }}</div>
+                                        {% endif %}
+                                        {% if addr.broadcast %}
+                                        <div class="small text-muted">Broadcast: {{ addr.broadcast }}</div>
+                                        {% endif %}
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                                {% endif %}
+                                
+                                {% if interface.stats %}
+                                <div class="system-info-item">
+                                    <strong>Speed:</strong> {{ interface.stats.speed }} Mbps
+                                </div>
+                                <div class="system-info-item">
+                                    <strong>MTU:</strong> {{ interface.stats.mtu }}
+                                </div>
+                                {% endif %}
+                                
+                                {% if interface.io_counters %}
+                                <div class="row mt-2">
+                                    <div class="col-6 text-center">
+                                        <div class="small text-muted">Bytes Sent</div>
+                                        <div class="fw-bold">{{ (interface.io_counters.bytes_sent / 1024 / 1024) | round(2) }} MB</div>
+                                    </div>
+                                    <div class="col-6 text-center">
+                                        <div class="small text-muted">Bytes Received</div>
+                                        <div class="fw-bold">{{ (interface.io_counters.bytes_recv / 1024 / 1024) | round(2) }} MB</div>
+                                    </div>
+                                </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Floating refresh button -->
+<button id="floatingRefreshBtn" class="btn btn-primary refresh-btn">
+    <i class="fas fa-sync-alt"></i>
+</button>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    $(document).ready(function() {
+        // Handle refresh button click
+        $('#refreshBtn, #floatingRefreshBtn').click(function() {
+            location.reload();
+        });
+        
+        // Auto-refresh every 60 seconds
+        setTimeout(function() {
+            location.reload();
+        }, 60000);
+    });
+</script>
+{% endblock %}

--- a/utils/system_monitor.py
+++ b/utils/system_monitor.py
@@ -1,0 +1,270 @@
+import psutil
+import platform
+import datetime
+import logging
+from datetime import timedelta
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    filename='system_monitor.log',
+    filemode='a'
+)
+logger = logging.getLogger('system_monitor')
+
+def get_system_info():
+    """Get basic system information."""
+    try:
+        info = {
+            'system': platform.system(),
+            'node': platform.node(),
+            'release': platform.release(),
+            'version': platform.version(),
+            'machine': platform.machine(),
+            'processor': platform.processor(),
+            'python_version': platform.python_version(),
+        }
+        return info
+    except Exception as e:
+        logger.error(f"Error getting system info: {str(e)}")
+        return {
+            'error': f"Failed to retrieve system information: {str(e)}"
+        }
+
+def get_cpu_info():
+    """Get CPU information and usage."""
+    try:
+        cpu_info = {
+            'physical_cores': psutil.cpu_count(logical=False),
+            'total_cores': psutil.cpu_count(logical=True),
+            'cpu_percent': psutil.cpu_percent(interval=1, percpu=True),
+            'cpu_freq': {
+                'current': psutil.cpu_freq().current if psutil.cpu_freq() else None,
+                'min': psutil.cpu_freq().min if psutil.cpu_freq() and hasattr(psutil.cpu_freq(), 'min') else None,
+                'max': psutil.cpu_freq().max if psutil.cpu_freq() and hasattr(psutil.cpu_freq(), 'max') else None
+            },
+            'cpu_stats': dict(psutil.cpu_stats()._asdict()) if hasattr(psutil, 'cpu_stats') else {},
+            'cpu_times_percent': dict(psutil.cpu_times_percent()._asdict())
+        }
+        
+        # Add overall CPU usage
+        cpu_info['overall_percent'] = sum(cpu_info['cpu_percent']) / len(cpu_info['cpu_percent'])
+        
+        return cpu_info
+    except Exception as e:
+        logger.error(f"Error getting CPU info: {str(e)}")
+        return {
+            'error': f"Failed to retrieve CPU information: {str(e)}"
+        }
+
+def get_memory_info():
+    """Get memory usage information."""
+    try:
+        # Virtual memory
+        virtual_memory = psutil.virtual_memory()
+        swap_memory = psutil.swap_memory()
+        
+        memory_info = {
+            'virtual': {
+                'total': virtual_memory.total,
+                'available': virtual_memory.available,
+                'used': virtual_memory.used,
+                'percent': virtual_memory.percent,
+                'total_gb': round(virtual_memory.total / (1024**3), 2),
+                'available_gb': round(virtual_memory.available / (1024**3), 2),
+                'used_gb': round(virtual_memory.used / (1024**3), 2)
+            },
+            'swap': {
+                'total': swap_memory.total,
+                'used': swap_memory.used,
+                'free': swap_memory.free,
+                'percent': swap_memory.percent,
+                'total_gb': round(swap_memory.total / (1024**3), 2),
+                'used_gb': round(swap_memory.used / (1024**3), 2),
+                'free_gb': round(swap_memory.free / (1024**3), 2)
+            }
+        }
+        
+        return memory_info
+    except Exception as e:
+        logger.error(f"Error getting memory info: {str(e)}")
+        return {
+            'error': f"Failed to retrieve memory information: {str(e)}"
+        }
+
+def get_disk_info():
+    """Get disk usage information."""
+    try:
+        disk_info = {
+            'partitions': [],
+            'io_counters': {}
+        }
+        
+        # Get disk partitions
+        for partition in psutil.disk_partitions():
+            try:
+                partition_usage = psutil.disk_usage(partition.mountpoint)
+                disk_info['partitions'].append({
+                    'device': partition.device,
+                    'mountpoint': partition.mountpoint,
+                    'fstype': partition.fstype,
+                    'opts': partition.opts,
+                    'total': partition_usage.total,
+                    'used': partition_usage.used,
+                    'free': partition_usage.free,
+                    'percent': partition_usage.percent,
+                    'total_gb': round(partition_usage.total / (1024**3), 2),
+                    'used_gb': round(partition_usage.used / (1024**3), 2),
+                    'free_gb': round(partition_usage.free / (1024**3), 2)
+                })
+            except (PermissionError, FileNotFoundError) as e:
+                # Skip partitions that can't be accessed
+                logger.warning(f"Could not access partition {partition.mountpoint}: {str(e)}")
+                continue
+        
+        # Get disk I/O counters
+        try:
+            io_counters = psutil.disk_io_counters(perdisk=True)
+            for disk, counters in io_counters.items():
+                disk_info['io_counters'][disk] = dict(counters._asdict())
+        except Exception as e:
+            logger.warning(f"Could not get disk I/O counters: {str(e)}")
+        
+        return disk_info
+    except Exception as e:
+        logger.error(f"Error getting disk info: {str(e)}")
+        return {
+            'error': f"Failed to retrieve disk information: {str(e)}"
+        }
+
+def get_network_info():
+    """Get network information and statistics."""
+    try:
+        network_info = {
+            'interfaces': {},
+            'connections': []
+        }
+        
+        # Get network interfaces
+        net_if_addrs = psutil.net_if_addrs()
+        net_if_stats = psutil.net_if_stats()
+        
+        for interface, addrs in net_if_addrs.items():
+            addresses = []
+            for addr in addrs:
+                addresses.append({
+                    'family': str(addr.family),
+                    'address': addr.address,
+                    'netmask': addr.netmask,
+                    'broadcast': addr.broadcast
+                })
+            
+            # Add interface stats if available
+            if interface in net_if_stats:
+                stats = net_if_stats[interface]
+                network_info['interfaces'][interface] = {
+                    'addresses': addresses,
+                    'stats': {
+                        'isup': stats.isup,
+                        'duplex': str(stats.duplex),
+                        'speed': stats.speed,
+                        'mtu': stats.mtu
+                    }
+                }
+            else:
+                network_info['interfaces'][interface] = {
+                    'addresses': addresses
+                }
+        
+        # Get network I/O counters
+        net_io_counters = psutil.net_io_counters(pernic=True)
+        for interface, counters in net_io_counters.items():
+            if interface in network_info['interfaces']:
+                network_info['interfaces'][interface]['io_counters'] = dict(counters._asdict())
+        
+        # Get network connections (limited due to permissions)
+        try:
+            connections = psutil.net_connections(kind='inet')
+            for conn in connections:
+                network_info['connections'].append({
+                    'fd': conn.fd,
+                    'family': str(conn.family),
+                    'type': str(conn.type),
+                    'laddr': f"{conn.laddr.ip}:{conn.laddr.port}" if conn.laddr else None,
+                    'raddr': f"{conn.raddr.ip}:{conn.raddr.port}" if conn.raddr else None,
+                    'status': conn.status,
+                    'pid': conn.pid
+                })
+        except (psutil.AccessDenied, PermissionError) as e:
+            logger.warning(f"Could not get network connections due to permissions: {str(e)}")
+            network_info['connections_error'] = "Permission denied to access network connections"
+        
+        return network_info
+    except Exception as e:
+        logger.error(f"Error getting network info: {str(e)}")
+        return {
+            'error': f"Failed to retrieve network information: {str(e)}"
+        }
+
+def get_system_uptime():
+    """Get system uptime information."""
+    try:
+        # Get boot time
+        boot_time = datetime.datetime.fromtimestamp(psutil.boot_time())
+        uptime = datetime.datetime.now() - boot_time
+        
+        # Format uptime
+        days, remainder = divmod(uptime.total_seconds(), 86400)
+        hours, remainder = divmod(remainder, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        
+        uptime_info = {
+            'boot_time': boot_time.strftime('%Y-%m-%d %H:%M:%S'),
+            'uptime_seconds': uptime.total_seconds(),
+            'uptime_formatted': f"{int(days)} days, {int(hours)} hours, {int(minutes)} minutes",
+            'days': int(days),
+            'hours': int(hours),
+            'minutes': int(minutes),
+            'seconds': int(seconds)
+        }
+        
+        return uptime_info
+    except Exception as e:
+        logger.error(f"Error getting system uptime: {str(e)}")
+        return {
+            'error': f"Failed to retrieve system uptime: {str(e)}"
+        }
+
+def get_system_load():
+    """Get system load averages (1, 5, 15 minutes)."""
+    try:
+        load_avg = psutil.getloadavg()
+        load_info = {
+            'load_1_min': load_avg[0],
+            'load_5_min': load_avg[1],
+            'load_15_min': load_avg[2],
+            'cpu_count': psutil.cpu_count(logical=True),
+            'normalized_load_1': load_avg[0] / psutil.cpu_count(logical=True),
+            'normalized_load_5': load_avg[1] / psutil.cpu_count(logical=True),
+            'normalized_load_15': load_avg[2] / psutil.cpu_count(logical=True)
+        }
+        return load_info
+    except Exception as e:
+        logger.error(f"Error getting system load: {str(e)}")
+        return {
+            'error': f"Failed to retrieve system load: {str(e)}"
+        }
+
+def get_all_system_metrics():
+    """Get all system metrics in a single call."""
+    return {
+        'system_info': get_system_info(),
+        'cpu_info': get_cpu_info(),
+        'memory_info': get_memory_info(),
+        'disk_info': get_disk_info(),
+        'network_info': get_network_info(),
+        'uptime_info': get_system_uptime(),
+        'load_info': get_system_load(),
+        'timestamp': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    }


### PR DESCRIPTION
This PR adds a System Health Dashboard feature to PortGuardian. 

## Features Added
- New System Health Dashboard page showing CPU, memory, disk, and network metrics
- Real-time system metrics using psutil
- Auto-refreshing dashboard
- Responsive design for all metrics
- API endpoint for system health data

## Testing
Tested on macOS with Python 3.9.

Closes #1